### PR TITLE
Add project ID parameter to deployment script 

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -31,6 +31,7 @@ gcloud functions deploy google-cloud-release-notes-function \
 
 # Create the Cloud Scheduler trigger.
 gcloud scheduler jobs create http google-cloud-release-notes-schedule \
+    --project=${project_id} \
     --location=us-central1 \
     --schedule="${schedule}" \
     --uri=https://us-central1-${project_id}.cloudfunctions.net/google-cloud-release-notes-function \
@@ -39,4 +40,4 @@ gcloud scheduler jobs create http google-cloud-release-notes-schedule \
 
 
 # Force run the Cloud Scheduler to initialize the table.
-gcloud scheduler jobs run google-cloud-release-notes-schedule --location=us-central1
+gcloud scheduler jobs run google-cloud-release-notes-schedule --location=us-central1 --project=${project_id}


### PR DESCRIPTION
adding project ID parameter to certain commands of the deploy script so that ressources get deployed to the project that was specified in the deployment script parameters.

I tried to deploy it as is and the cloud scheduler job was deployed to the GCP project that was set by default through the Gcloud CLI